### PR TITLE
feat: allow custom openweathermap api keys

### DIFF
--- a/internal/api/handlers/handlers_test.go
+++ b/internal/api/handlers/handlers_test.go
@@ -17,8 +17,8 @@ import (
 )
 
 type WeatherClientInterface interface {
-	GetCoordinates(city string) (*models.City, error)
-	GetWeather(lat, lon float64, units string) (*models.OneCallResponse, error)
+	GetCoordinates(city string, customApiKey string) (*models.City, error)
+	GetWeather(lat, lon float64, units string, customApiKey string) (*models.OneCallResponse, error)
 	SearchCities(query string, limit int) ([]models.City, error)
 }
 
@@ -26,12 +26,12 @@ type MockWeatherClient struct {
 	mock.Mock
 }
 
-func (m *MockWeatherClient) GetCoordinates(city string) (*models.City, error) {
+func (m *MockWeatherClient) GetCoordinates(city string, customApiKey string) (*models.City, error) {
 	args := m.Called(city)
 	return args.Get(0).(*models.City), args.Error(1)
 }
 
-func (m *MockWeatherClient) GetWeather(lat, lon float64, units string) (*models.OneCallResponse, error) {
+func (m *MockWeatherClient) GetWeather(lat, lon float64, units string, customApiKey string) (*models.OneCallResponse, error) {
 	args := m.Called(lat, lon, units)
 	return args.Get(0).(*models.OneCallResponse), args.Error(1)
 }
@@ -112,18 +112,19 @@ func (m *MockGitHubOAuth) GetUserInfo(token string) (*models.User, error) {
 func TestWeatherHandler_GetWeather(t *testing.T) {
 	mockClient := new(MockWeatherClient)
 
+	var apiKey string
 	getWeatherHandler := func(w http.ResponseWriter, r *http.Request) {
 		vars := mux.Vars(r)
 		cityName := vars["city"]
 		units := r.URL.Query().Get("units")
 
-		city, err := mockClient.GetCoordinates(cityName)
+		city, err := mockClient.GetCoordinates(cityName, apiKey)
 		if err != nil {
 			http.Error(w, "Error finding city", http.StatusNotFound)
 			return
 		}
 
-		weather, err := mockClient.GetWeather(city.Lat, city.Lon, units)
+		weather, err := mockClient.GetWeather(city.Lat, city.Lon, units, apiKey)
 		if err != nil {
 			http.Error(w, "Error getting weather", http.StatusInternalServerError)
 			return

--- a/internal/api/middleware/auth.go
+++ b/internal/api/middleware/auth.go
@@ -4,16 +4,19 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/josephburgess/breeze/internal/logging"
+	"github.com/josephburgess/breeze/internal/models"
 	"github.com/josephburgess/breeze/internal/services/store"
 )
 
 type contextKey string
 
 const (
-	UserContextKey contextKey = "user"
+	UserContextKey      contextKey = "user"
+	CustomApiContextKey contextKey = "custom-api-user"
 )
 
 func ApiKeyAuth(userStore *store.UserStore) func(http.Handler) http.Handler {
@@ -24,6 +27,23 @@ func ApiKeyAuth(userStore *store.UserStore) func(http.Handler) http.Handler {
 			if apiKey == "" {
 				logging.Warn("API key is missing in request")
 				http.Error(w, "API key is required", http.StatusUnauthorized)
+				return
+			}
+
+			if !strings.HasPrefix(apiKey, "gust_") {
+				logging.Info("User has provided a custom API key")
+				user := &models.User{
+					ID:        0,
+					GithubID:  0,
+					Login:     "custom-api-user",
+					CreatedAt: time.Now(),
+					LastLogin: time.Now(),
+				}
+
+				ctx := context.WithValue(r.Context(), UserContextKey, user)
+				ctx = context.WithValue(ctx, CustomApiContextKey, apiKey)
+
+				next.ServeHTTP(w, r.WithContext(ctx))
 				return
 			}
 

--- a/internal/services/weather/client.go
+++ b/internal/services/weather/client.go
@@ -24,8 +24,12 @@ func NewClient(apiKey string) *Client {
 	}
 }
 
-func (c *Client) GetCoordinates(city string) (*models.City, error) {
-	url := fmt.Sprintf("%sgeo/1.0/direct?q=%s&limit=1&appid=%s", c.BaseURL, city, c.ApiKey)
+func (c *Client) GetCoordinates(city string, customApiKey string) (*models.City, error) {
+	apiKey := c.ApiKey
+	if customApiKey != "" {
+		apiKey = customApiKey
+	}
+	url := fmt.Sprintf("%sgeo/1.0/direct?q=%s&limit=1&appid=%s", c.BaseURL, city, apiKey)
 	logging.Info("Fetching coordinates for city: %s", city)
 
 	resp, err := http.Get(url)
@@ -50,12 +54,15 @@ func (c *Client) GetCoordinates(city string) (*models.City, error) {
 	return &cities[0], nil
 }
 
-func (c *Client) GetWeather(lat, lon float64, units string) (*models.OneCallResponse, error) {
+func (c *Client) GetWeather(lat, lon float64, units string, customApiKey string) (*models.OneCallResponse, error) {
 	var url string
-
+	apiKey := c.ApiKey
+	if customApiKey != "" {
+		apiKey = customApiKey
+	}
 	if units != "" {
 		url = fmt.Sprintf("%sdata/3.0/onecall?lat=%f&lon=%f&appid=%s&units=%s",
-			c.BaseURL, lat, lon, c.ApiKey, units)
+			c.BaseURL, lat, lon, apiKey, units)
 		logging.Info("Fetching weather data with units=%s", units)
 	} else {
 		url = fmt.Sprintf("%sdata/3.0/onecall?lat=%f&lon=%f&appid=%s",

--- a/internal/services/weather/weather_test.go
+++ b/internal/services/weather/weather_test.go
@@ -12,6 +12,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+var apiKey string
+
 func TestClient_GetCoordinates(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		assert.Equal(t, "/geo/1.0/direct", r.URL.Path)
@@ -36,7 +38,7 @@ func TestClient_GetCoordinates(t *testing.T) {
 
 	client.BaseURL = server.URL + "/"
 
-	city, err := client.GetCoordinates("London")
+	city, err := client.GetCoordinates("London", apiKey)
 
 	require.NoError(t, err)
 	require.NotNil(t, city)
@@ -57,7 +59,7 @@ func TestClient_GetCoordinates_NotFound(t *testing.T) {
 	client := weather.NewClient("test-api-key")
 	client.BaseURL = server.URL + "/"
 
-	city, err := client.GetCoordinates("NonExistentCity")
+	city, err := client.GetCoordinates("NonExistentCity", apiKey)
 
 	assert.Error(t, err)
 	assert.Nil(t, city)
@@ -106,7 +108,7 @@ func TestClient_GetWeather(t *testing.T) {
 	client := weather.NewClient("test-api-key")
 	client.BaseURL = server.URL + "/"
 
-	weather, err := client.GetWeather(51.5074, -0.1278, "metric")
+	weather, err := client.GetWeather(51.5074, -0.1278, "metric", apiKey)
 
 	require.NoError(t, err)
 	require.NotNil(t, weather)
@@ -140,7 +142,7 @@ func TestClient_GetWeather_DefaultUnits(t *testing.T) {
 	client := weather.NewClient("test-api-key")
 	client.BaseURL = server.URL + "/"
 
-	weather, err := client.GetWeather(51.5074, -0.1278, "")
+	weather, err := client.GetWeather(51.5074, -0.1278, "", apiKey)
 
 	require.NoError(t, err)
 	require.NotNil(t, weather)


### PR DESCRIPTION

Allow users to include their own custom openweathermap api key instead of requiring a gust api key.
